### PR TITLE
adds `active-entry` event which is always emitted before `custom key`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ It contains some text wrapped with double braces {{}}. These wrapped text indica
 |------------------------|--------------------|-----------------------------------------------------------|
 | input change           | INPUT_CHANGE       | sent when input changes and input action is set to `send` |
 | custom key             | CUSTOM_KEY         | sent when a custom key is typed                           |
+| active entry           | ACTIVE_ENTRY       | sent before `custom key` event is emitted                 |
 | select entry           | SELECT_ENTRY       | sent when selecting an entry on the list                  |
 | delete entry           | DELETE_ENTRY       | sent when deleting an entry on the list                   |
 | execute custom input   | EXEC_CUSTOM_INPUT  | sent when a custom input is to be executed                |

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -79,6 +79,7 @@ size_t NUM_OF_INPUT_ACTIONS = NELEMS(input_action_names);
 typedef enum {
     Event__INPUT_CHANGE,
     Event__CUSTOM_KEY,
+    Event__ACTIVE_ENTRY,
     Event__SELECT_ENTRY, 
     Event__DELETE_ENTRY, 
     Event__EXEC_CUSTOM_INPUT
@@ -87,6 +88,7 @@ typedef enum {
 static const char *event_enum_labels[] = {
     "INPUT_CHANGE",
     "CUSTOM_KEY",
+    "ACTIVE_ENTRY", 
     "SELECT_ENTRY", 
     "DELETE_ENTRY", 
     "EXEC_CUSTOM_INPUT"
@@ -95,6 +97,7 @@ static const char *event_enum_labels[] = {
 static const char *event_labels[] = {
     "input change",
     "custom key",
+    "active entry",
     "select entry",
     "delete entry",
     "execute custom input"
@@ -627,7 +630,11 @@ static ModeMode blocks_mode_result ( Mode *sw, int mretv, char **input, unsigned
         int custom_key = retv%20 + 1;
         char str[8];
         snprintf(str, 8, "%d", custom_key);
+
+        LineData * lineData = &g_array_index (pageData->lines, LineData, selected_line);
+        blocks_mode_private_data_write_to_channel(data, Event__ACTIVE_ENTRY, lineData->text);
         blocks_mode_private_data_write_to_channel(data, Event__CUSTOM_KEY, str);
+
         retv = RELOAD_DIALOG;
     } else if ( ( mretv & MENU_OK ) ) {
         LineData * lineData = &g_array_index (pageData->lines, LineData, selected_line);
@@ -637,8 +644,7 @@ static ModeMode blocks_mode_result ( Mode *sw, int mretv, char **input, unsigned
         LineData * lineData = &g_array_index (pageData->lines, LineData, selected_line);
         blocks_mode_private_data_write_to_channel(data, Event__DELETE_ENTRY, lineData->text);
         retv = RELOAD_DIALOG;
-    }
-     else if ( ( mretv & MENU_CUSTOM_INPUT ) ) {
+    } else if ( ( mretv & MENU_CUSTOM_INPUT ) ) {
         blocks_mode_private_data_write_to_channel(data, Event__EXEC_CUSTOM_INPUT, *input);
         retv = RELOAD_DIALOG;
     }


### PR DESCRIPTION
Currently `custom-key` event does not have many use cases as there is no way to get actively selected line/record with it.  

This fixes that, and basically emits 2 events when custom key is pressed.  
First it emits `active-entry` with currently selected record followed by `custom-key` event which signalizes which key was pressed.

This implementation is compatible with current design, that is, writes events in any user defined format (default json) delimited by `\n` (new line) control character.  
To parse the `custom key` event in default format, the user has to split incoming data with `\n` and then parse individual segment as json messages.  This is not ideal but its the only way how to not break to current design... 

In the future it would be good choice to drop custom event format feature and support only `json`. It would make `rofi-blocks` more scalable and consistent.