### PR TITLE
Check for cairo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,7 @@ dnl ---------------------------------------------------------------------
 dnl PKG_CONFIG based dependencies  
 dnl ---------------------------------------------------------------------
 PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0 json-glib-1.0])
+PKG_CHECK_MODULES([cairo],    [cairo])
 PKG_CHECK_MODULES([rofi],     [rofi])
 
 [rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,7 @@ blocks_la_SOURCES=\
 		page_data.c \
 		render_state.c
 
-blocks_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@
-blocks_la_LIBADD= @glib_LIBS@ @rofi_LIBS@
+blocks_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@ @cairo_CFLAGS@
+blocks_la_LIBADD= @glib_LIBS@ @rofi_LIBS@ @cairo_LIBS@
 blocks_la_LDFLAGS= -module -avoid-version
 


### PR DESCRIPTION
cairo is a dependency for rofi and this adds it to the search path
Also without this, the code will not compile in nixos