### PR TITLE
fix: Fix error unknown type name 'JsonNode' in page_data.h

### DIFF
--- a/src/page_data.h
+++ b/src/page_data.h
@@ -5,6 +5,7 @@
 #define ROFI_BLOCKS_PAGE_DATA_H
 #include <gmodule.h>
 #include <stdint.h>
+#include <json-glib/json-glib.h>
 typedef enum 
 {
 	MarkupStatus_UNDEFINED = 0,


### PR DESCRIPTION
Fixes the following compile error:

    In file included from check_page_data.c:4:
    ../src/page_data.h:59:56: error: unknown type name 'JsonNode'
       59 | void page_data_add_line_json_node(PageData * pageData, JsonNode * element);