### PR TITLE
test: Fix outdated page_data_add_line call in check_page_data

### DIFF
--- a/tests/check_page_data.c
+++ b/tests/check_page_data.c
@@ -15,7 +15,7 @@ int main(void)
     test_uint_equals(.result = page_data_get_number_of_lines(page_data), .expected = 0);
 
 
-    page_data_add_line(page_data, "aaa", true, true, true);
+    page_data_add_line(page_data, "aaa", "any-icon", "any-data", true, true, true);
     test_string_equals(.result =  page_data_get_line_by_index_or_else(page_data, 0, NULL)->text, .expected= "aaa");
     test_true(page_data_get_line_by_index_or_else(page_data, -1, NULL) == NULL);
     test_true(page_data_get_line_by_index_or_else(NULL, 0, NULL) == NULL);


### PR DESCRIPTION
    check_page_data.c:18:5: error: too few arguments to function 'page_data_add_line'
       18 |     page_data_add_line(page_data, "aaa", true, true, true);
          |     ^~~~~~~~~~~~~~~~~~
    In file included from check_page_data.c:4:
    ../src/page_data.h:58:6: note: declared here
       58 | void page_data_add_line(PageData * pageData, const gchar * label, const gchar * icon, const gchar * data, gboolean urgent, gboolean highlight, gboolean markup);
          |      ^~~~~~~~~~~~~~~~~~