### PR TITLE
fix: Fix format string in blocks.c - use %li instead of %i

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -221,7 +221,7 @@ static gboolean on_new_input ( GIOChannel *source, GIOCondition condition, gpoin
 
         if(willFocusToEntry){
             RofiViewState * rofiViewState = rofi_view_get_active();
-            g_debug("entry_to_focus %i", entry_to_focus);
+            g_debug("entry_to_focus %li", entry_to_focus);
             rofi_view_set_selected_line(rofiViewState, (unsigned int) entry_to_focus);
         }
 


### PR DESCRIPTION
    blocks.c:224:21: warning: format '%i' expects argument of type 'int', but argument 4 has type 'gint64' {aka 'long int'} [-Wformat=]
      224 |             g_debug("entry_to_focus %i", entry_to_focus);
          |                     ^~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~
          |                                          |
          |                                          gint64 {aka long int}
    blocks.c:224:38: note: format string is defined here
      224 |             g_debug("entry_to_focus %i", entry_to_focus);
          |                                     ~^
          |                                      |
          |                                      int
          |                                     %li